### PR TITLE
Feature fix old print statements

### DIFF
--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     # Known bug: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
     - name: fix code coverage paths
       run: |
-        sed -i 's/\/home\/runner\/work\/openstf-db-connector\/openstf-db-connector\//\/github\/workspace\//g' coverage.xml
+        sed -i 's/\/home\/runner\/work\/openstf-dbc\/openstf-dbc\//\/github\/workspace\//g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: openstf-db-connector
+Upstream-Name: openstf-dbc
 Upstream-Contact: Korte Termijn Prognoses <korte.termijn.prognoses@alliander.com>
-Source: https://github.com/alliander-opensource/openstf-db-connector
+Source: https://github.com/alliander-opensource/openstf-dbc
 
 Files: tests/*
 Copyright: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com>

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ SPDX-FileCopyrightText: 2021 2017-2021 Alliander N.V. <korte.termijn.prognoses@a
 
 SPDX-License-Identifier: MPL-2.0
 -->
-[![Python Build](https://github.com/alliander-opensource/openstf-db-connector/actions/workflows/python-build.yaml/badge.svg?branch=master)](https://github.com/alliander-opensource/openstf-db-connector/actions/workflows/python-build.yaml)
-[![REUSE Compliance Check](https://github.com/alliander-opensource/openstf-db-connector/actions/workflows/reuse-compliance.yml/badge.svg?branch=master)](https://github.com/alliander-opensource/openstf-db-connector/actions/workflows/reuse-compliance.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf-db-connector&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf-db-connector)
+[![Python Build](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/python-build.yaml/badge.svg?branch=master)](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/python-build.yaml)
+[![REUSE Compliance Check](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/reuse-compliance.yml/badge.svg?branch=master)](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/reuse-compliance.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf-dbc&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf-dbc)
 
 
-# Openstf-db-connector - Database connector for OpenSTF (reference)
-This repository houses the python package [openstf-dbc](https://pypi.org/project/openstf-dbc/), which provides an interface to OpenSTF (reference) databases. 
+# openstf-dbc - Database connector for OpenSTF (reference)
+This repository houses the python package [openstf-dbc](https://pypi.org/project/openstf-dbc/), which provides an interface to OpenSTF (reference) databases.
 Related projects:
 - [OpenSTF-reference](https://github.com/alliander-opensource/openstf-reference)
 - [OpenSTF](https://github.com/alliander-opensource/short-term-forecasting)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ SPDX-License-Identifier: MPL-2.0
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf-dbc&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf-dbc)
 
 
-# openstf-dbc - Database connector for OpenSTF (reference)
-This repository houses the python package [openstf-dbc](https://pypi.org/project/openstf-dbc/), which provides an interface to OpenSTF (reference) databases.
+# openstf-dbc - Database connector for openstf (reference)
+
+This repository houses the python package [openstf-dbc](https://pypi.org/project/openstf-dbc/), which provides an interface to openstf (reference) databases.
+
 Related projects:
-- [OpenSTF-reference](https://github.com/alliander-opensource/openstf-reference)
-- [OpenSTF](https://github.com/alliander-opensource/short-term-forecasting)
+- [openstf-reference](https://github.com/alliander-opensource/openstf-reference)
+- [openstf](https://github.com/alliander-opensource/short-term-forecasting)
 
 
 ## Install
@@ -22,8 +24,8 @@ Related projects:
 
 ## Usage
 
-This is a package with functionality to support the OpenSTF workflow. Most important is the DataBase class.
-This class give access to the data used by Openstf-reference via a convenient interface. You can use it, for example, to retrieve a prediction job by running the following lines of code:
+This is a package with functionality to support the openstf workflow. Most important is the DataBase class.
+This class give access to the data used by openstf-reference via a convenient interface. You can use it, for example, to retrieve a prediction job by running the following lines of code:
 
 ```python
 from openstf_dbc.database import DataBase

--- a/openstf_dbc/services/model_input.py
+++ b/openstf_dbc/services/model_input.py
@@ -16,6 +16,10 @@ from openstf_dbc.services.predictor import Predictor
 
 # TODO refactor and include in preprocessing and make uniform for making predictions and training models
 class ModelInput:
+
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger(self.__class__.__name__)
+
     def get_model_input(
         self,
         pid=295,
@@ -128,7 +132,7 @@ class ModelInput:
                 axis=1,
             )
         else:
-            print("Warning: No load data returned!")
+            self.logger.warning("No load data returned.")
             result["load"] = np.nan
         if apx_data is not None:
             result = pd.concat(
@@ -187,16 +191,16 @@ class ModelInput:
         # sid selection for pvdata
         if radius == 0:
             if sid is None:
-                # print("radius is zero and no sid was given, selecting nearest system")
+                self.logger.debug("Radius is zero and no sid was given, selecting nearest system")
                 systems = systems_service.get_systems_near_location(location, freq=5)
                 sid = systems.loc[0].sid  # select nearest system
-            # print("Using system", sid, "for this prediction.")
+                self.logger.debug("Nearest system is {sid}")
         else:
             systems = systems_service.get_systems_near_location(
                 location, radius, freq=5
             )
             sid = systems.sid
-            # print("Found", len(systems), "systems for this prediction.")
+            self.logger.debug(f"Found {len(systems)} systems near this location")
 
         # Get weather data
         weather_params = ["radiation", "clouds"]

--- a/openstf_dbc/services/model_input.py
+++ b/openstf_dbc/services/model_input.py
@@ -7,6 +7,7 @@ import pytz
 
 import numpy as np
 import pandas as pd
+import structlog
 
 from openstf_dbc.data_interface import _DataInterface
 from openstf_dbc.services.weather import Weather

--- a/openstf_dbc/services/prediction_job.py
+++ b/openstf_dbc/services/prediction_job.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import json
+from sys import exc_info
 
 from openstf_dbc.data_interface import _DataInterface
 from openstf_dbc.services.systems import Systems
@@ -278,12 +279,13 @@ class PredictionJob:
         Returns:
             (datetime) last: Datetime of last hyperparameters
         """
-        query = f""" SELECT MAX(hpv.created) as last
-                    FROM hyper_params hp
-                    LEFT JOIN hyper_param_values hpv
-                        ON hpv.hyper_params_id=hp.id
-                    WHERE hpv.prediction_id={pj["id"]} AND hp.model="{pj["model"]}"
-                    """
+        query = f"""
+            SELECT MAX(hpv.created) as last
+            FROM hyper_params hp
+            LEFT JOIN hyper_param_values hpv
+                ON hpv.hyper_params_id=hp.id
+            WHERE hpv.prediction_id={pj["id"]} AND hp.model="{pj["model"]}"
+        """
         last = None
         try:
             # Execute query
@@ -292,13 +294,11 @@ class PredictionJob:
             last = result["last"][0].to_pydatetime()
             # If dictionary is empty raise exception and fall back to defaults
         except Exception as e:
-            print(
-                "Could not retrieve last hyperparemeters from database for pid {}\n".format(
-                    pj["id"]
-                ),
-                "Exception: ",
-                e,
+            self.logger.error(
+                'Could not retrieve last hyperparemeters from database '
+                f'for pid {pj["id"]}', exc_info=e
             )
+
         return last
 
     def get_hyper_params(self, pj):

--- a/openstf_dbc/services/weather.py
+++ b/openstf_dbc/services/weather.py
@@ -4,17 +4,22 @@
 
 from datetime import datetime, timedelta
 
+import geopy
+import geopy.distance
 import numpy as np
 import pandas as pd
-import geopy.distance
-import geopy
 import pytz
+import structlog
 
 from openstf_dbc.data_interface import _DataInterface
 from openstf_dbc.services.write import Write
 
 
 class Weather:
+
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger(self.__class__.__name__)
+
     def get_weather_forecast_locations(self, country="NL", active=1):
         """Get weather forecast locations.
 
@@ -274,12 +279,12 @@ class Weather:
             result = result["weather"]
             result.index.name = "datetime"
         else:
-            print("No weatherdata found. Returning empty dataframe")
+            self.logger.warning("No weatherdata found. Returning empty dataframe")
             return pd.DataFrame()
 
         # Create a single dataframe with combined sources
         if combine_sources:
-            print("Combining sources into single dataframe")
+            self.logger.info("Combining sources into single dataframe")
             result = self._combine_weather_sources(result)
 
         # Interpolate if nescesarry

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description="Database Connection for OpenSTF",
     long_description=read_long_description_from_readme(),
     long_description_content_type="text/markdown",
-    url="https://github.com/alliander-opensource/openstf-db-connector",
+    url="https://github.com/alliander-opensource/openstf-dbc",
     author="Alliander N.V",
     author_email="korte.termijn.prognoses@alliander.com",
     license="MPL-2.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 sonar.organization=alliander-opensource
-sonar.projectKey=alliander-opensource_openstf-db-connector
-sonar.projectName=openstf-db-connector
+sonar.projectKey=alliander-opensource_openstf-dbc
+sonar.projectName=openstf-dbc
 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 sonar.organization=alliander-opensource
-sonar.projectKey=alliander-opensource_openstf-dbc
+# TODO change to alliander-opensource_openstf-dbc
+sonar.projectKey=alliander-opensource_openstf-db-connector
 sonar.projectName=openstf-dbc
 
 # relative paths to source directories. More details and properties are described


### PR DESCRIPTION
Just a couple small fixes. There were still a couple methods which use plain `print()` instead of a logger. This PR replaces the `print()` calls with `logger.<level>()` calls. This looks better of course but also makes it possible to analyze the logs using tools like Elastic.