### PR TITLE
Log instead of raise warning

### DIFF
--- a/openstf_dbc/services/model_input.py
+++ b/openstf_dbc/services/model_input.py
@@ -60,7 +60,7 @@ class ModelInput:
             pid, datetime_start, datetime_end, forecast_resolution
         )
         if len(load) == 0:
-            raise Warning("Historic load is empty.")
+            self.logger.warning("Length of load data was 0")
 
         # Get APX price data
         apx_data = Predictor().get_apx(datetime_start, datetime_end)


### PR DESCRIPTION
Case for len(load)==0 is already covered by L134.
By raising a warining, execution halts. Proposed solution: log the warning, and let the code which calls this function deal with the case where len(load)==0 appropriately.

Old implementation leads to a hard-to-capture warning, proposed implementation allows for nice capturing of exception at the right level.

![image](https://user-images.githubusercontent.com/18208480/128328339-d209e9c8-aa1c-446e-952c-63503eb1e403.png)
^old implementation