### PR TITLE
Feature KTPS-1521 add external id to prediction job

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: MPL-2.0
 -->
 [![Python Build](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/python-build.yaml/badge.svg?branch=master)](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/python-build.yaml)
 [![REUSE Compliance Check](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/reuse-compliance.yml/badge.svg?branch=master)](https://github.com/alliander-opensource/openstf-dbc/actions/workflows/reuse-compliance.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf-dbc&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf-dbc)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf-db-connector&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf-db-connector)
 
-
+```
 # Openstf-dbc - Database connector for openstf (reference)
 
 This repository houses the python package [openstf-dbc](https://pypi.org/project/openstf-dbc/), which provides an interface to openstf (reference) databases.

--- a/openstf_dbc/services/prediction_job.py
+++ b/openstf_dbc/services/prediction_job.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import json
-from sys import exc_info
 from typing import List, Optional, Union
 
 from openstf_dbc.data.featuresets import FEATURESET_NAMES, FEATURESETS

--- a/openstf_dbc/services/prediction_job.py
+++ b/openstf_dbc/services/prediction_job.py
@@ -229,8 +229,9 @@ class PredictionJob:
 
         query = f"""
             SELECT
-                p.id, p.forecast_type, p.model, p.horizon_minutes, p.resolution_minutes,
-                p.train_components, p.name,
+                p.id, p.name,
+                p.forecast_type, p.model, p.horizon_minutes, p.resolution_minutes,
+                p.train_components, p.external_id
                 min(s.lat) as lat,
                 min(s.lon) as lon,
                 min(s.sid) as sid,

--- a/openstf_dbc/services/prediction_job.py
+++ b/openstf_dbc/services/prediction_job.py
@@ -117,16 +117,15 @@ class PredictionJob:
             GROUP BY p.id
         """
 
-        result = _DataInterface.get_instance().exec_sql_query(query)
+        results = _DataInterface.get_instance().exec_sql_query(query)
 
         # Convert to list of dictionaries
-        result = result.to_dict(orient="records")
+        prediction_jobs = results.to_dict(orient="records")
 
-        # Add description field
-        for pj in result:
-            systems = Systems().get_systems_by_pid(pj["id"])
-            pj["description"] = "+".join(list(systems.system_id))
-        return result
+        # Add description to all prediction jobs
+        prediction_jobs = self._add_description_to_prediction_jobs(prediction_jobs)
+
+        return prediction_jobs
 
     def get_prediction_jobs_solar(self):
         query = """
@@ -148,16 +147,15 @@ class PredictionJob:
             GROUP BY p.id
         """
 
-        result = _DataInterface.get_instance().exec_sql_query(query)
+        results = _DataInterface.get_instance().exec_sql_query(query)
 
         # Convert to list of dictionaries
-        result = result.to_dict(orient="records")
+        prediction_jobs = results.to_dict(orient="records")
 
-        # Add description field
-        for pj in result:
-            systems = Systems().get_systems_by_pid(pj["id"])
-            pj["description"] = "+".join(list(systems.system_id))
-        return result
+        # Add description to all prediction jobs
+        prediction_jobs = self._add_description_to_prediction_jobs(prediction_jobs)
+
+        return prediction_jobs
 
     def get_hyper_params(self, pj):
         """Method that finds the latest hyperparameters for a specific prediction job.

--- a/openstf_dbc/services/prediction_job.py
+++ b/openstf_dbc/services/prediction_job.py
@@ -16,79 +16,6 @@ class PredictionJob:
     def __init__(self):
         self.logger = logging.get_logger(self.__class__.__name__)
 
-    def _add_description_to_prediction_job(self, prediction_job):
-        return self._add_description_to_prediction_jobs([prediction_job])[0]
-
-    def _add_description_to_prediction_jobs(self, prediction_jobs):
-
-        for prediction_job in prediction_jobs:
-            systems = Systems().get_systems_by_pid(
-                pid=prediction_job["id"], return_list=True
-            )
-            systems_str = "+".join([s["system_id"] for s in systems])
-            prediction_job["description"] = systems_str
-
-        return prediction_jobs
-
-    def _add_model_type_group_to_prediction_jobs(self, prediction_jobs):
-        for prediction_job in prediction_jobs:
-            # TODO this needs to be changed in the
-            if "quantile" in prediction_job["model"]:
-                prediction_job["model_type_group"] = "quantile"
-            else:
-                prediction_job["model_type_group"] = "default"
-
-        return prediction_jobs
-
-    def _add_model_type_group_to_prediction_job(self, prediction_job):
-        return self._add_model_type_group_to_prediction_jobs([prediction_job])[0]
-
-    def _add_quantiles_to_prediciton_job(self, prediction_job):
-        return self._add_quantiles_to_prediciton_jobs([prediction_job])[0]
-
-    def _add_quantiles_to_prediciton_jobs(self, prediction_jobs):
-        prediction_job_ids = [pj["id"] for pj in prediction_jobs]
-        prediction_jobs_ids_str = ", ".join([f"'{p}'" for p in prediction_job_ids])
-
-        query = f"""
-            SELECT p.id AS prediction_id, qs.quantiles
-            FROM quantile_sets AS qs
-            JOIN (
-                predictions_quantile_sets AS pq,
-                predictions as p
-            )
-            WHERE
-                p.id = pq.prediction_id AND
-                qs.id = pq.quantile_set_id AND
-                p.id IN  ({prediction_jobs_ids_str})
-            ORDER BY prediction_id
-            ;
-        """
-        result = _DataInterface.get_instance().exec_sql_query(query)
-
-        prediction_job_quantiles = {}
-
-        # get quantiles for every prediction job
-        for _, row in result.iterrows():
-            pid = row["prediction_id"]
-
-            if pid not in prediction_job_quantiles:
-                prediction_job_quantiles[pid] = []
-
-            prediction_job_quantiles[pid] += json.loads(row["quantiles"])
-
-        # add quantiles to prediction job
-        for prediction_job in prediction_jobs:
-            pid = prediction_job["id"]
-            # add quantiles if any
-            if pid in prediction_job_quantiles:
-                prediction_job["quantiles"] = sorted(prediction_job_quantiles[pid])
-                continue
-            # add empty list if none (this should not actually happen)
-            prediction_job["quantiles"] = []
-
-        return prediction_jobs
-
     def get_prediction_job(self, pid, model_type=None, is_active=None):
         """Get prediction job for a given pid from the database.
 
@@ -169,6 +96,220 @@ class PredictionJob:
 
         # Add model group
         prediction_jobs = self._add_model_type_group_to_prediction_jobs(prediction_jobs)
+
+        return prediction_jobs
+
+    def get_prediction_jobs_wind(self):
+        query = """
+            SELECT
+                p.id, p.forecast_type, p.model, p.horizon_minutes, p.resolution_minutes,
+                p.name,
+                min(s.sid) as sid,
+                w.lat as lat,
+                w.lon as lon,
+                w.turbine_type,
+                w.n_turbines,
+                w.hub_height
+            FROM predictions as p
+            LEFT JOIN predictions_systems as ps ON p.id = ps.prediction_id
+            LEFT JOIN systems as s ON s.sid = ps.system_id
+            LEFT JOIN windspecs as w ON p.id = w.pid
+            WHERE p.forecast_type = 'wind' AND p.active = 1
+            GROUP BY p.id
+        """
+
+        result = _DataInterface.get_instance().exec_sql_query(query)
+
+        # Convert to list of dictionaries
+        result = result.to_dict(orient="records")
+
+        # Add description field
+        for pj in result:
+            systems = Systems().get_systems_by_pid(pj["id"])
+            pj["description"] = "+".join(list(systems.system_id))
+        return result
+
+    def get_prediction_jobs_solar(self):
+        query = """
+            SELECT
+                p.id, p.forecast_type, p.model, p.horizon_minutes, p.resolution_minutes,
+                p.name,
+                min(s.lat) as lat,
+                min(s.lon) as lon,
+                min(s.sid) as sid,
+                ss.lat,
+                ss.lon,
+                ss.radius,
+                ss.peak_power
+            FROM predictions as p
+            LEFT JOIN predictions_systems as ps ON p.id = ps.prediction_id
+            LEFT JOIN systems as s ON s.sid = ps.system_id
+            LEFT JOIN solarspecs as ss ON p.id = ss.pid
+            WHERE p.forecast_type = 'solar' AND p.active = 1
+            GROUP BY p.id
+        """
+
+        result = _DataInterface.get_instance().exec_sql_query(query)
+
+        # Convert to list of dictionaries
+        result = result.to_dict(orient="records")
+
+        # Add description field
+        for pj in result:
+            systems = Systems().get_systems_by_pid(pj["id"])
+            pj["description"] = "+".join(list(systems.system_id))
+        return result
+
+    def get_hyper_params(self, pj):
+        """Method that finds the latest hyperparameters for a specific prediction job.
+        Args:
+            pj: Prediction job (dict).
+
+        Returns:
+            (dict) params: Dictionary with hyperparameters.
+                Empty if no hyperparameters excist or in case of errors.
+        """
+        # Compose query
+        query = f"""
+            SELECT hp.name, hpv.value
+            FROM hyper_params hp
+            LEFT JOIN hyper_param_values hpv
+                ON hpv.hyper_params_id=hp.id
+            WHERE hpv.prediction_id="{pj["id"]}" AND hp.model="{pj["model"]}"
+        """
+        # Default params is empty dict
+        params = {}
+
+        try:
+            # Execute query
+            result = _DataInterface.get_instance().exec_sql_query(query)
+            # Convert result to dict with proper keys
+            params = result.set_index("name").to_dict()["value"]
+        except Exception as e:
+            self.logger.error(
+                "Error occured while retrieving hyper parameters",
+                exc_info=e,
+                pid=pj["id"],
+            )
+
+        return params
+
+    def get_hyper_params_last_optimized(self, pj):
+        """Method that finds the date of the most recent hyperparameters
+        Args:
+            pj: Prediction job (dict).
+        Returns:
+            (datetime) last: Datetime of last hyperparameters
+        """
+        query = f"""
+            SELECT MAX(hpv.created) as last
+            FROM hyper_params hp
+            LEFT JOIN hyper_param_values hpv
+                ON hpv.hyper_params_id=hp.id
+            WHERE hpv.prediction_id={pj["id"]} AND hp.model="{pj["model"]}"
+        """
+        last = None
+        try:
+            # Execute query
+            result = _DataInterface.get_instance().exec_sql_query(query)
+            # Convert result datetime instance
+            last = result["last"][0].to_pydatetime()
+            # If dictionary is empty raise exception and fall back to defaults
+        except Exception as e:
+            self.logger.error(
+                "Could not retrieve last hyperparemeters from database "
+                f'for pid {pj["id"]}',
+                exc_info=e,
+            )
+
+        return last
+
+    def get_featureset(self, featureset_name):
+
+        if featureset_name not in FEATURESET_NAMES:
+            raise KeyError(
+                f"Unknown featureset name '{featureset_name}'. "
+                f"Valid names are {', '.join(FEATURESET_NAMES)}"
+            )
+
+        return FEATURESETS[featureset_name]
+
+    def get_featuresets(self):
+        return FEATURESETS
+
+    def get_featureset_names(self):
+        return FEATURESET_NAMES
+
+    def _add_description_to_prediction_job(self, prediction_job):
+        return self._add_description_to_prediction_jobs([prediction_job])[0]
+
+    def _add_description_to_prediction_jobs(self, prediction_jobs):
+
+        for prediction_job in prediction_jobs:
+            systems = Systems().get_systems_by_pid(
+                pid=prediction_job["id"], return_list=True
+            )
+            systems_str = "+".join([s["system_id"] for s in systems])
+            prediction_job["description"] = systems_str
+
+        return prediction_jobs
+
+    def _add_model_type_group_to_prediction_jobs(self, prediction_jobs):
+        for prediction_job in prediction_jobs:
+            # TODO this needs to be changed in the
+            if "quantile" in prediction_job["model"]:
+                prediction_job["model_type_group"] = "quantile"
+            else:
+                prediction_job["model_type_group"] = "default"
+
+        return prediction_jobs
+
+    def _add_model_type_group_to_prediction_job(self, prediction_job):
+        return self._add_model_type_group_to_prediction_jobs([prediction_job])[0]
+
+    def _add_quantiles_to_prediciton_job(self, prediction_job):
+        return self._add_quantiles_to_prediciton_jobs([prediction_job])[0]
+
+    def _add_quantiles_to_prediciton_jobs(self, prediction_jobs):
+        prediction_job_ids = [pj["id"] for pj in prediction_jobs]
+        prediction_jobs_ids_str = ", ".join([f"'{p}'" for p in prediction_job_ids])
+
+        query = f"""
+            SELECT p.id AS prediction_id, qs.quantiles
+            FROM quantile_sets AS qs
+            JOIN (
+                predictions_quantile_sets AS pq,
+                predictions as p
+            )
+            WHERE
+                p.id = pq.prediction_id AND
+                qs.id = pq.quantile_set_id AND
+                p.id IN  ({prediction_jobs_ids_str})
+            ORDER BY prediction_id
+            ;
+        """
+        result = _DataInterface.get_instance().exec_sql_query(query)
+
+        prediction_job_quantiles = {}
+
+        # get quantiles for every prediction job
+        for _, row in result.iterrows():
+            pid = row["prediction_id"]
+
+            if pid not in prediction_job_quantiles:
+                prediction_job_quantiles[pid] = []
+
+            prediction_job_quantiles[pid] += json.loads(row["quantiles"])
+
+        # add quantiles to prediction job
+        for prediction_job in prediction_jobs:
+            pid = prediction_job["id"]
+            # add quantiles if any
+            if pid in prediction_job_quantiles:
+                prediction_job["quantiles"] = sorted(prediction_job_quantiles[pid])
+                continue
+            # add empty list if none (this should not actually happen)
+            prediction_job["quantiles"] = []
 
         return prediction_jobs
 
@@ -268,144 +409,3 @@ class PredictionJob:
         else:
             raise ValueError("external_id should be str or list of str")
         return f"p.external_id IN ({in_values})"
-
-    def get_prediction_jobs_wind(self):
-        query = """
-            SELECT
-                p.id, p.forecast_type, p.model, p.horizon_minutes, p.resolution_minutes,
-                p.name,
-                min(s.sid) as sid,
-                w.lat as lat,
-                w.lon as lon,
-                w.turbine_type,
-                w.n_turbines,
-                w.hub_height
-            FROM predictions as p
-            LEFT JOIN predictions_systems as ps ON p.id = ps.prediction_id
-            LEFT JOIN systems as s ON s.sid = ps.system_id
-            LEFT JOIN windspecs as w ON p.id = w.pid
-            WHERE p.forecast_type = 'wind' AND p.active = 1
-            GROUP BY p.id
-        """
-
-        result = _DataInterface.get_instance().exec_sql_query(query)
-
-        # Convert to list of dictionaries
-        result = result.to_dict(orient="records")
-
-        # Add description field
-        for pj in result:
-            systems = Systems().get_systems_by_pid(pj["id"])
-            pj["description"] = "+".join(list(systems.system_id))
-        return result
-
-    def get_prediction_jobs_solar(self):
-        query = """
-            SELECT
-                p.id, p.forecast_type, p.model, p.horizon_minutes, p.resolution_minutes,
-                p.name,
-                min(s.lat) as lat,
-                min(s.lon) as lon,
-                min(s.sid) as sid,
-                ss.lat,
-                ss.lon,
-                ss.radius,
-                ss.peak_power
-            FROM predictions as p
-            LEFT JOIN predictions_systems as ps ON p.id = ps.prediction_id
-            LEFT JOIN systems as s ON s.sid = ps.system_id
-            LEFT JOIN solarspecs as ss ON p.id = ss.pid
-            WHERE p.forecast_type = 'solar' AND p.active = 1
-            GROUP BY p.id
-        """
-
-        result = _DataInterface.get_instance().exec_sql_query(query)
-
-        # Convert to list of dictionaries
-        result = result.to_dict(orient="records")
-
-        # Add description field
-        for pj in result:
-            systems = Systems().get_systems_by_pid(pj["id"])
-            pj["description"] = "+".join(list(systems.system_id))
-        return result
-
-    def get_hyper_params_last_optimized(self, pj):
-        """Method that finds the date of the most recent hyperparameters
-        Args:
-            pj: Prediction job (dict).
-        Returns:
-            (datetime) last: Datetime of last hyperparameters
-        """
-        query = f"""
-            SELECT MAX(hpv.created) as last
-            FROM hyper_params hp
-            LEFT JOIN hyper_param_values hpv
-                ON hpv.hyper_params_id=hp.id
-            WHERE hpv.prediction_id={pj["id"]} AND hp.model="{pj["model"]}"
-        """
-        last = None
-        try:
-            # Execute query
-            result = _DataInterface.get_instance().exec_sql_query(query)
-            # Convert result datetime instance
-            last = result["last"][0].to_pydatetime()
-            # If dictionary is empty raise exception and fall back to defaults
-        except Exception as e:
-            self.logger.error(
-                "Could not retrieve last hyperparemeters from database "
-                f'for pid {pj["id"]}',
-                exc_info=e,
-            )
-
-        return last
-
-    def get_hyper_params(self, pj):
-        """Method that finds the latest hyperparameters for a specific prediction job.
-        Args:
-            pj: Prediction job (dict).
-
-        Returns:
-            (dict) params: Dictionary with hyperparameters.
-                Empty if no hyperparameters excist or in case of errors.
-        """
-        # Compose query
-        query = f"""
-            SELECT hp.name, hpv.value
-            FROM hyper_params hp
-            LEFT JOIN hyper_param_values hpv
-                ON hpv.hyper_params_id=hp.id
-            WHERE hpv.prediction_id="{pj["id"]}" AND hp.model="{pj["model"]}"
-        """
-        # Default params is empty dict
-        params = {}
-
-        try:
-            # Execute query
-            result = _DataInterface.get_instance().exec_sql_query(query)
-            # Convert result to dict with proper keys
-            params = result.set_index("name").to_dict()["value"]
-        except Exception as e:
-            self.logger.error(
-                "Error occured while retrieving hyper parameters",
-                exc_info=e,
-                pid=pj["id"],
-            )
-
-        return params
-
-    def get_featureset(self, featureset_name):
-
-        if featureset_name not in FEATURESET_NAMES:
-            raise KeyError(
-                f"Unknown featureset name '{featureset_name}'. "
-                f"Valid names are {', '.join(FEATURESET_NAMES)}"
-            )
-
-        return FEATURESETS[featureset_name]
-
-    def get_featuresets(self):
-        return FEATURESETS
-
-    def get_featureset_names(self):
-        return FEATURESET_NAMES

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 pkg_dir = Path(__file__).parent.absolute()
 
@@ -28,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf_dbc",
-    version="1.1.0",
+    version="1.2.0",
     packages=find_packages(include=["openstf_dbc", "openstf_dbc.*"]),
     description="Database Connection for OpenSTF",
     long_description=read_long_description_from_readme(),

--- a/tests/unit/services/test_database_prediction_job.py
+++ b/tests/unit/services/test_database_prediction_job.py
@@ -15,6 +15,22 @@ class TestPredictionJob(unittest.TestCase):
         super().setUp()
         self.service = PredictionJob()
 
+    def test_build_get_prediction_jobs_query(self):
+        kwargs = {
+            "pid": 123,
+            "model_type": "xgb",
+            "active": 1,
+            "only_ato": True,
+            "external_id": "e179c450-30cc-4fb8-a9c8-1cd6feee2cbd",
+            "limit": 999,
+        }
+        query = PredictionJob.build_get_prediction_jobs_query(**kwargs)
+        for key, value in kwargs.items():
+            if key == "only_ato":
+                self.assertTrue("ATO" in query)
+                continue
+            self.assertTrue(value in query)
+
     def test_get_featureset(self, data_interface_mock):
         featureset_names = self.service.get_featureset_names()
         for name in featureset_names:

--- a/tests/unit/services/test_database_prediction_job.py
+++ b/tests/unit/services/test_database_prediction_job.py
@@ -44,6 +44,12 @@ class TestPredictionJob(unittest.TestCase):
 
         self.service.get_prediction_jobs()
 
+    def test_get_prediction_jobs_wind_result_size_is_zero(self, data_interface_mock):
+        self.service.get_prediction_jobs_wind()
+
+    def test_get_prediction_jobs_solar_result_size_is_zero(self, data_interface_mock):
+        self.service.get_prediction_jobs_solar()
+
     def test_build_get_prediction_jobs_query(self, *args, **kwargs):
         kwargs = {
             "pid": 123,
@@ -65,6 +71,10 @@ class TestPredictionJob(unittest.TestCase):
         for name in featureset_names:
             featureset = self.service.get_featureset(name)
             self.assertEqual(type(featureset), list)
+
+    def test_get_featureset_wrong_name(self, data_interface_mock):
+        with self.assertRaises(KeyError):
+            self.service.get_featureset("wrong_name")
 
     def test_get_featuresets(self, data_interface_mock):
         self.assertEqual(type(self.service.get_featuresets()), dict)

--- a/tests/unit/services/test_database_prediction_job.py
+++ b/tests/unit/services/test_database_prediction_job.py
@@ -6,14 +6,43 @@
 import unittest
 from unittest.mock import patch
 
+import pandas
+import pandas as pd
 from openstf_dbc.services.prediction_job import PredictionJob
 
+prediction_job = {
+    "id": 307,
+    "name": "Neerijnen",
+    "forecast_type": "demand",
+    "model": "xgb",
+    "horizon_minutes": 2880,
+    "resolution_minutes": 15,
+    "train_components": 1,
+    "external_id": None,
+    "lat": 51.8336647,
+    "lon": 5.2137814,
+    "sid": "LC_Neerijnen",
+    "created": pd.Timestamp("2019-04-05 12:08:23"),
+}
 
-@patch("openstf_dbc.services.predictions._DataInterface")
+
+@patch("openstf_dbc.services.prediction_job._DataInterface")
 class TestPredictionJob(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.service = PredictionJob()
+
+    def test_get_prediction_job_result_size_is_zero(self, data_interface_mock):
+        data_interface_mock.get_instance.return_value.exec_sql_query.return_value = (
+            pd.DataFrame()
+        )
+
+        with self.assertRaises(ValueError):
+            self.service.get_prediction_job(pid=307)
+
+    def test_get_prediction_jobs_result_size_is_zero(self, data_interface_mock):
+
+        self.service.get_prediction_jobs()
 
     def test_build_get_prediction_jobs_query(self, *args, **kwargs):
         kwargs = {

--- a/tests/unit/services/test_database_prediction_job.py
+++ b/tests/unit/services/test_database_prediction_job.py
@@ -15,11 +15,11 @@ class TestPredictionJob(unittest.TestCase):
         super().setUp()
         self.service = PredictionJob()
 
-    def test_build_get_prediction_jobs_query(self):
+    def test_build_get_prediction_jobs_query(self, *args, **kwargs):
         kwargs = {
             "pid": 123,
             "model_type": "xgb",
-            "active": 1,
+            "is_active": 1,
             "only_ato": True,
             "external_id": "e179c450-30cc-4fb8-a9c8-1cd6feee2cbd",
             "limit": 999,
@@ -29,7 +29,7 @@ class TestPredictionJob(unittest.TestCase):
             if key == "only_ato":
                 self.assertTrue("ATO" in query)
                 continue
-            self.assertTrue(value in query)
+            self.assertTrue(str(value) in query)
 
     def test_get_featureset(self, data_interface_mock):
         featureset_names = self.service.get_featureset_names()


### PR DESCRIPTION
De PR voeg de mogelijkheid toe om prediction job's op te halen voor een `external_id`. Het `external_id` is net als `model_type`, `is_active` etc. geimplementeerd als een filter optie voor `get_prediciton_jobs`. 

Ik heb er toch maar voor gekozen om het `external_id` toe te voegen aan de prediction_job. Hiermee kan je dan ook controleren dat je idd de prediction job voor de gewenste mrid/external_id gekregen hebt. Of is het misschien beter om dat niet te doen? De prediction job word door onze hele code gebruikt, dan sleep je dat id dus door allerlei interfaces heen?
