### PR TITLE
Make datetime processing more robust and uniform

### DIFF
--- a/openstf_dbc/services/model_input.py
+++ b/openstf_dbc/services/model_input.py
@@ -14,7 +14,7 @@ from openstf_dbc.services.ems import Ems
 from openstf_dbc.services.predictor import Predictor
 from openstf_dbc.services.systems import Systems
 from openstf_dbc.services.weather import Weather
-from openstf_dbc.utils import genereate_datetime_index
+from openstf_dbc.utils import genereate_datetime_index, process_datetime_range
 
 
 class ModelInput:
@@ -55,6 +55,13 @@ class ModelInput:
         if datetime_end is None:
             datetime_end = datetime.utcnow().date() + timedelta(3)
 
+        # Process datetimes (rounded, timezone, frequency) and generate index
+        datetime_start, datetime_end, datetime_index = process_datetime_range(
+            start=datetime_start,
+            end=datetime_end,
+            freq=forecast_resolution,
+        )
+
         # Get load
         load = Ems().get_load_pid(
             pid, datetime_start, datetime_end, forecast_resolution
@@ -69,13 +76,7 @@ class ModelInput:
         )
 
         # Create model input with datetime index
-        model_input = pd.DataFrame(
-            index=genereate_datetime_index(
-                start=datetime_start,
-                end=datetime_end,
-                freq=forecast_resolution,
-            )
-        )
+        model_input = pd.DataFrame(index=datetime_index)
         model_input.index.name = "index"
 
         # Add load if available, else add nan column

--- a/openstf_dbc/services/model_input.py
+++ b/openstf_dbc/services/model_input.py
@@ -14,7 +14,7 @@ from openstf_dbc.services.ems import Ems
 from openstf_dbc.services.predictor import Predictor
 from openstf_dbc.services.systems import Systems
 from openstf_dbc.services.weather import Weather
-from openstf_dbc.utils import genereate_datetime_index, process_datetime_range
+from openstf_dbc.utils import process_datetime_range
 
 
 class ModelInput:

--- a/openstf_dbc/services/predictor.py
+++ b/openstf_dbc/services/predictor.py
@@ -50,7 +50,6 @@ class Predictor:
             end=datetime_end,
             freq=forecast_resolution,
         )
-
         if predictor_groups is None:
             predictor_groups = [p for p in PredictorGroups]
 
@@ -99,11 +98,20 @@ class Predictor:
     def get_electricity_price(
         self, datetime_start, datetime_end, forecast_resolution=None
     ):
-        query = 'SELECT "Price" FROM "forecast_latest".."marketprices" \
-        WHERE "Name" = \'APX\' AND time >= \'{}\' AND time <= \'{}\''.format(
-            datetime_start, datetime_end
-        )
-
+        # query = 'SELECT "Price" FROM "forecast_latest".."marketprices" \
+        # WHERE "Name" = \'APX\' AND time >= \'{}\' AND time <= \'{}\''.format(
+        #     datetime_start, datetime_end
+        # )
+        database = "forecast_latest"
+        measurement = "marketprices"
+        query = f"""
+            SELECT
+                "Price" FROM "{database}".."{measurement}"
+            WHERE
+                "Name" = 'APX' AND
+                time >= '{datetime_start.isoformat()}' AND
+                time <= '{datetime_end.isoformat()}'
+        """
         electricity_price = _DataInterface.get_instance().exec_influx_query(query)
 
         if not electricity_price:
@@ -163,11 +171,18 @@ class Predictor:
         # (there is also a 'year_created' tag in this measurement)
         database = "realised"
         measurement = "sjv"
-        query = f"""
-            SELECT /^sjv/ FROM "{database}".."{measurement}"
-            WHERE time >= '{datetime_start}' AND time <= '{datetime_end}'
-        """
+        # query = f"""
+        #     SELECT /^sjv/ FROM "{database}".."{measurement}"
+        #     WHERE time >= '{datetime_start.isoformat()}' AND time <= '{datetime_end.isoformat()}'
+        # """
 
+        query = f"""
+            SELECT
+                /^sjv/ FROM "{database}".."{measurement}"
+            WHERE
+                time >= '{datetime_start.isoformat()}' AND
+                time <= '{datetime_end.isoformat()}'
+        """
         load_profiles = _DataInterface.get_instance().exec_influx_query(query)
 
         if not load_profiles:
@@ -183,7 +198,6 @@ class Predictor:
             load_profiles = load_profiles.resample(forecast_resolution).interpolate(
                 limit=3
             )
-
         return load_profiles
 
     def get_weather_data(

--- a/openstf_dbc/services/predictor.py
+++ b/openstf_dbc/services/predictor.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Tuple, Union
 import pandas as pd
 from openstf_dbc.data_interface import _DataInterface
 from openstf_dbc.services.weather import Weather
-from openstf_dbc.utils import genereate_datetime_index
+from openstf_dbc.utils import genereate_datetime_index, process_datetime_range
 
 
 class PredictorGroups(Enum):
@@ -32,8 +32,8 @@ class Predictor:
         selected. If the WEATHER_DATA group is included a location is required.
 
         Args:
-            datetime_start (str):
-            datetime_end (str):
+            datetime_start (datetime): Date time end.
+            datetime_end (datetime): Date time start.
             location (Union[str, Tuple[float, float]], optional): Location (for weather data).
                 Defaults to None.
             predictor_groups (Optional[List[str]], optional): The groups of predictors
@@ -43,6 +43,14 @@ class Predictor:
         Returns:
             pd.DataFrame: Requested predictors with timezone aware datetime index.
         """
+
+        # Process datetimes (rounded, timezone, frequency) and generate index
+        datetime_start, datetime_end, datetime_index = process_datetime_range(
+            start=datetime_start,
+            end=datetime_end,
+            freq=forecast_resolution,
+        )
+
         if predictor_groups is None:
             predictor_groups = [p for p in PredictorGroups]
 
@@ -53,13 +61,7 @@ class Predictor:
             raise ValueError(
                 "Need to provide a location when weather data predictors are requested."
             )
-        predictors = pd.DataFrame(
-            index=genereate_datetime_index(
-                start=datetime_start,
-                end=datetime_end,
-                freq=forecast_resolution,
-            )
-        )
+        predictors = pd.DataFrame(index=datetime_index)
 
         if PredictorGroups.WEATHER_DATA in predictor_groups:
             weather_data_predictors = self.get_weather_data(
@@ -107,9 +109,7 @@ class Predictor:
         if not electricity_price:
             return pd.DataFrame(
                 index=genereate_datetime_index(
-                    start=datetime_start,
-                    end=datetime_end,
-                    freq=forecast_resolution,
+                    start=datetime_start, end=datetime_end, freq=forecast_resolution
                 )
             )
 
@@ -134,9 +134,7 @@ class Predictor:
         if gas_price.empty:
             return pd.DataFrame(
                 index=genereate_datetime_index(
-                    start=datetime_start,
-                    end=datetime_end,
-                    freq=forecast_resolution,
+                    start=datetime_start, end=datetime_end, freq=forecast_resolution
                 )
             )
 
@@ -175,9 +173,7 @@ class Predictor:
         if not load_profiles:
             return pd.DataFrame(
                 index=genereate_datetime_index(
-                    start=datetime_start,
-                    end=datetime_end,
-                    freq=forecast_resolution,
+                    start=datetime_start, end=datetime_end, freq=forecast_resolution
                 )
             )
 

--- a/openstf_dbc/services/predictor.py
+++ b/openstf_dbc/services/predictor.py
@@ -98,10 +98,6 @@ class Predictor:
     def get_electricity_price(
         self, datetime_start, datetime_end, forecast_resolution=None
     ):
-        # query = 'SELECT "Price" FROM "forecast_latest".."marketprices" \
-        # WHERE "Name" = \'APX\' AND time >= \'{}\' AND time <= \'{}\''.format(
-        #     datetime_start, datetime_end
-        # )
         database = "forecast_latest"
         measurement = "marketprices"
         query = f"""
@@ -171,10 +167,6 @@ class Predictor:
         # (there is also a 'year_created' tag in this measurement)
         database = "realised"
         measurement = "sjv"
-        # query = f"""
-        #     SELECT /^sjv/ FROM "{database}".."{measurement}"
-        #     WHERE time >= '{datetime_start.isoformat()}' AND time <= '{datetime_end.isoformat()}'
-        # """
 
         query = f"""
             SELECT

--- a/openstf_dbc/services/weather.py
+++ b/openstf_dbc/services/weather.py
@@ -205,8 +205,8 @@ class Weather:
             weatherparams  (str or list of str): weatherparams that are required.
                 Params include: ["clouds", "radiation", "temp", "winddeg", "windspeed", "windspeed_100m", "pressure",
                 "humidity", "rain", 'mxlD', 'snowDepth', 'clearSky_ulf', 'clearSky_dlf', 'ssrunoff']
-            datetime_start (datetime) : start of datetimeFC. Default: 14 days ago
-            datetime_end (datetime): latest datetimeFC. Default: now + 2 days.
+            datetime_start (datetime) : start date time. Default: 14 days ago
+            datetime_end (datetime): end date time. Default: now + 2 days.
             source (str or list of str): which weather models should be used.
                 Options: "OWM", "DSN", "WUN", "harmonie", "harm_arome", "optimum"
                 Default: 'optimum'. This combines harmonie, harm_arome and DSN,

--- a/openstf_dbc/services/weather.py
+++ b/openstf_dbc/services/weather.py
@@ -224,20 +224,24 @@ class Weather:
 
         if datetime_start is None:
             datetime_start = datetime.utcnow() - timedelta(days=14)
+
         datetime_start = pd.to_datetime(datetime_start)
 
         if datetime_end is None:
             datetime_end = datetime.utcnow() + timedelta(days=2)
+
         datetime_end = pd.to_datetime(datetime_end)
 
         # Convert to UTC and remove UTC as note
         if datetime_start.tz is not None:
             datetime_start = datetime_start.tz_convert("UTC").tz_localize(None)
+
         if datetime_end.tz is not None:
             datetime_end = datetime_end.tz_convert("UTC").tz_localize(None)
 
         # Get data from an hour earlier to correct for radiation shift later
         datetime_start_original = datetime_start.tz_localize("UTC")
+
         datetime_start -= timedelta(hours=1)
 
         location_name = self._get_nearest_weather_location(location)

--- a/openstf_dbc/utils.py
+++ b/openstf_dbc/utils.py
@@ -16,9 +16,23 @@ def genereate_datetime_index(start, end, freq=None):
     if not freq:
         freq = DEFAULT_FREQ
 
-    return pd.date_range(
+    datetime_index = pd.date_range(
         start=start,
         end=end,
         freq=freq,
         tz=tz,
     )
+    # Round to given frequency
+    datetime_index = datetime_index.round(freq)
+
+    return datetime_index
+
+
+def process_datetime_range(start, end, freq=None):
+    datetime_index = genereate_datetime_index(start, end, freq)
+
+    # Use the index to generate valid start and end times
+    datetime_start = datetime_index[0].to_pydatetime()
+    datetime_end = datetime_index[-1].to_pydatetime()
+
+    return datetime_start, datetime_end, datetime_index

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf_dbc",
-    version="2.0.0",
+    version="2.0.1",
     packages=find_packages(include=["openstf_dbc", "openstf_dbc.*"]),
     description="Database Connection for OpenSTF",
     long_description=read_long_description_from_readme(),


### PR DESCRIPTION
Er leken toch nog wel wat problemen met datetime's te zijn in `get_model_input()` en `get_predictors()`. Deze PR probeert deze issues op te lossen.

* een default timezone wordt toegevoegd als er geen timezone informatie is
  * zowel aan start en end datetime als de datetime_index
* De start en eind tijd wordt altijd afgerond naar de gevraagde resolutie (bijv. 15min)
* De start en eind tijd wordt afgeleid uit de gegenereerde index zodat deze altijd goed zijn.

Laat maar horen of dit een goede oplossing is. (Het zou misschien nog wat verder uitgerold moeten worden ??) Misschien kan het nog makkelijker? Je wilt gewoon één functie call hebben om je datumtijd dingen goed te zetten denk ik. Misschien moeten we nog stricter zijn en bijv. ook pytz.UTC omzetten naar timezone.utc dat we maar één formaat UTC accepteren. Of misschien willen we het wel andersom pytz.UTC de default maken.

**TODO**

* Eventueel alle datetime manipulaties in get_weather_data gelijk trekken
* Use cases uitwerken en testen
  * niet afgeronde datetime's als input
  * Geen tijdzone informatie
  * Andere tijdzone informatie (geen default timezone.utc)
    * getest met timezone.utc en pytz.UTC, beide lijken nu goed te werken
  * Bepalen wat de default timezone is (nu timezone.utc misschien is pytz.utc toch beter?)
  * Unit/integratie testen maken
  * Alle datetime argumenten zijn hetzelfde type: datetime lijkt voor de hand liggend.
  * docstrings updaten
  * Altijd dezelfde datetime to str conversie toepassen waarschijnlijk `isoformat()` (misschien anders voor mysql en influxdb?)
  * Default start en end datetimes worden op dezelfde manier gemaakt voor alle functies.